### PR TITLE
Cleanups: Consolidate enums, attrStats cleanup

### DIFF
--- a/src/attack_calculator.ts
+++ b/src/attack_calculator.ts
@@ -1,13 +1,6 @@
 import { AttackType, EvasiveStatType } from 'base_game_enums';
 import { Character } from 'character';
 
-// Note that these enums/ util classes should likely be moved elsewhere eventually
-interface ToHitResults {
-    doesAttackHit: boolean;
-    attackerToHit: number;
-    defenderEvade: number;
-}
-
 function getEvasiveStatTypeForAttackType(attackType: AttackType) : EvasiveStatType {
     switch (attackType) {
         case AttackType.Strike:
@@ -20,6 +13,12 @@ function getEvasiveStatTypeForAttackType(attackType: AttackType) : EvasiveStatTy
         default:
             throw `Unknown attackType ${attackType}`;
     }
+}
+
+interface ToHitResults {
+    doesAttackHit: boolean;
+    attackerToHit: number;
+    defenderEvade: number;
 }
 
 /*

--- a/src/attack_calculator.ts
+++ b/src/attack_calculator.ts
@@ -1,27 +1,7 @@
-import { DamageType, ResistanceStats } from 'resistance_stats';
+import { Attribute, AttackType, EvasiveStatType, DamageType } from 'base_game_enums';
+import { ResistanceStats } from 'resistance_stats';
 
 // Note that these enums/ util classes should likely be moved elsewhere eventually
-export enum Attribute {
-    Constitution,
-    Strength,
-    Dexterity,
-    Wisdom,
-    Intelligence,
-    Charisma,
-}
-
-export enum AttackType {
-    Strike,
-    Projectile,
-    Curse,
-}
-
-export enum EvasiveStatType {
-    Fortitude,
-    Reflex,
-    Willpower,
-}
-
 export interface Weapon {
     attribute: Attribute;
     attackType: AttackType;
@@ -30,83 +10,41 @@ export interface Weapon {
     damageType: DamageType;
 }
 
-// TODO: does Record<Attribute, number> work, then get rid of this class?
 export class AttributeStats {
-    constitution: number;
-    strength: number;
-    dexterity: number;
-    wisdom: number;
-    intelligence: number;
-    charisma: number;
+    attributeToStat: Record<Attribute, number>;
 
     constructor({con, str, dex, wis, int, cha} : {
         con: number, str: number, dex: number, wis: number, int: number, cha: number
     }) {
-        this.constitution = con;
-        this.strength = str;
-        this.dexterity = dex;
-        this.wisdom = wis;
-        this.intelligence = int;
-        this.charisma = cha;
+        this.attributeToStat = {
+            [Attribute.Constitution]: con,
+            [Attribute.Strength]: str,
+            [Attribute.Dexterity]: dex,
+            [Attribute.Wisdom]: wis,
+            [Attribute.Intelligence]: int,
+            [Attribute.Charisma]: cha,
+        };
     }
 
-    getAttribute(attribute: Attribute) : number {
-        switch (attribute) {
-            case Attribute.Constitution:
-                return this.constitution;
-            case Attribute.Strength:
-                return this.strength;
-            case Attribute.Dexterity:
-                return this.dexterity;
-            case Attribute.Wisdom:
-                return this.wisdom;
-            case Attribute.Intelligence:
-                return this.intelligence;
-            case Attribute.Charisma:
-                return this.charisma;
-
-            default:
-                throw `Unknown attribute ${attribute}`;
-        }
+    get(attribute: Attribute) : number {
+        return this.attributeToStat[attribute];
     }
 
-    setAttribute(attribute: Attribute, value: number) {
-        switch (attribute) {
-            case Attribute.Constitution:
-                this.constitution = value;
-                break;
-            case Attribute.Strength:
-                this.strength = value;
-                break;
-            case Attribute.Dexterity:
-                this.dexterity = value;
-                break;
-            case Attribute.Wisdom:
-                this.wisdom = value;
-                break;
-            case Attribute.Intelligence:
-                this.intelligence = value;
-                break;
-            case Attribute.Charisma:
-                this.charisma = value;
-                break;
-
-            default:
-                throw `Unknown attribute ${attribute}`;
-        }
+    set(attribute: Attribute, value: number) {
+        this.attributeToStat[attribute] = value;
     }
 
     getEvasiveStat(evasiveStatType: EvasiveStatType) : number {
         let statSum: number;
         switch (evasiveStatType) {
             case EvasiveStatType.Fortitude:
-                statSum = this.constitution + this.strength;
+                statSum = this.get(Attribute.Constitution) + this.get(Attribute.Strength);
                 break;
             case EvasiveStatType.Reflex:
-                statSum = this.dexterity + this.wisdom;
+                statSum = this.get(Attribute.Dexterity) + this.get(Attribute.Wisdom);
                 break;
             case EvasiveStatType.Willpower:
-                statSum = this.intelligence + this.charisma;
+                statSum = this.get(Attribute.Intelligence) + this.get(Attribute.Charisma);
                 break;
 
             default:
@@ -158,7 +96,7 @@ Not yet implemented for toHit:
  */
 export function calculateToHit(roll: number, attacker: Character, defender: Character) : ToHitResults {
     const attackerWeaponAttributeToHit = Math.ceil(
-        attacker.attributeStats.getAttribute(attacker.weapon.attribute) *
+        attacker.attributeStats.get(attacker.weapon.attribute) *
         attacker.weapon.toHitMultiplier
     );
     const attackerToHit = attackerWeaponAttributeToHit - attacker.weapon.difficultyClass + roll;
@@ -180,7 +118,7 @@ Not yet implemented for damage:
 - Two handing weapon multiplier
 */
 export function calculateDamage(attacker: Character, defender: Character) : number {
-    const atkWeapStat = attacker.attributeStats.getAttribute(attacker.weapon.attribute);
+    const atkWeapStat = attacker.attributeStats.get(attacker.weapon.attribute);
     const defAttrRes = defender.resistanceStats.get(attacker.weapon.damageType);
     const calcDmg = Math.ceil(atkWeapStat * (1 - defAttrRes.percent)) - defAttrRes.flat;
     return Math.max(calcDmg, 1);

--- a/src/attack_calculator.ts
+++ b/src/attack_calculator.ts
@@ -1,72 +1,7 @@
-import { Attribute, AttackType, EvasiveStatType, DamageType } from 'base_game_enums';
-import { ResistanceStats } from 'resistance_stats';
+import { AttackType, EvasiveStatType } from 'base_game_enums';
+import { Character } from 'character';
 
 // Note that these enums/ util classes should likely be moved elsewhere eventually
-export interface Weapon {
-    attribute: Attribute;
-    attackType: AttackType;
-    toHitMultiplier: number;
-    difficultyClass: number;
-    damageType: DamageType;
-}
-
-export class AttributeStats {
-    attributeToStat: Record<Attribute, number>;
-
-    constructor({con, str, dex, wis, int, cha} : {
-        con: number, str: number, dex: number, wis: number, int: number, cha: number
-    }) {
-        this.attributeToStat = {
-            [Attribute.Constitution]: con,
-            [Attribute.Strength]: str,
-            [Attribute.Dexterity]: dex,
-            [Attribute.Wisdom]: wis,
-            [Attribute.Intelligence]: int,
-            [Attribute.Charisma]: cha,
-        };
-    }
-
-    get(attribute: Attribute) : number {
-        return this.attributeToStat[attribute];
-    }
-
-    set(attribute: Attribute, value: number) {
-        this.attributeToStat[attribute] = value;
-    }
-
-    getEvasiveStat(evasiveStatType: EvasiveStatType) : number {
-        let statSum: number;
-        switch (evasiveStatType) {
-            case EvasiveStatType.Fortitude:
-                statSum = this.get(Attribute.Constitution) + this.get(Attribute.Strength);
-                break;
-            case EvasiveStatType.Reflex:
-                statSum = this.get(Attribute.Dexterity) + this.get(Attribute.Wisdom);
-                break;
-            case EvasiveStatType.Willpower:
-                statSum = this.get(Attribute.Intelligence) + this.get(Attribute.Charisma);
-                break;
-
-            default:
-                throw `Unknown evasiveStatType ${evasiveStatType}`;
-        }
-
-        return Math.ceil(0.75 * statSum);
-    }
-}
-
-export class Character {
-    attributeStats: AttributeStats;
-    resistanceStats: ResistanceStats;
-    weapon: Weapon;
-
-    constructor(attrStats: AttributeStats, resStats: ResistanceStats, weap: Weapon) {
-        this.attributeStats = attrStats;
-        this.resistanceStats = resStats;
-        this.weapon = weap;
-    }
-}
-
 interface ToHitResults {
     doesAttackHit: boolean;
     attackerToHit: number;

--- a/src/attribute_stats.ts
+++ b/src/attribute_stats.ts
@@ -1,0 +1,46 @@
+import { Attribute, EvasiveStatType } from 'base_game_enums';
+
+export class AttributeStats {
+    attributeToStat: Record<Attribute, number>;
+
+    constructor({con, str, dex, wis, int, cha} : {
+        con: number, str: number, dex: number, wis: number, int: number, cha: number
+    }) {
+        this.attributeToStat = {
+            [Attribute.Constitution]: con,
+            [Attribute.Strength]: str,
+            [Attribute.Dexterity]: dex,
+            [Attribute.Wisdom]: wis,
+            [Attribute.Intelligence]: int,
+            [Attribute.Charisma]: cha,
+        };
+    }
+
+    get(attribute: Attribute) : number {
+        return this.attributeToStat[attribute];
+    }
+
+    set(attribute: Attribute, value: number) {
+        this.attributeToStat[attribute] = value;
+    }
+
+    getEvasiveStat(evasiveStatType: EvasiveStatType) : number {
+        let statSum: number;
+        switch (evasiveStatType) {
+            case EvasiveStatType.Fortitude:
+                statSum = this.get(Attribute.Constitution) + this.get(Attribute.Strength);
+                break;
+            case EvasiveStatType.Reflex:
+                statSum = this.get(Attribute.Dexterity) + this.get(Attribute.Wisdom);
+                break;
+            case EvasiveStatType.Willpower:
+                statSum = this.get(Attribute.Intelligence) + this.get(Attribute.Charisma);
+                break;
+
+            default:
+                throw `Unknown evasiveStatType ${evasiveStatType}`;
+        }
+
+        return Math.ceil(0.75 * statSum);
+    }
+}

--- a/src/attribute_stats.ts
+++ b/src/attribute_stats.ts
@@ -1,19 +1,14 @@
 import { Attribute, EvasiveStatType } from 'base_game_enums';
+import { enumerateEnumValues } from 'utils';
 
 export class AttributeStats {
     attributeToStat: Record<Attribute, number>;
 
-    constructor({con, str, dex, wis, int, cha} : {
-        con: number, str: number, dex: number, wis: number, int: number, cha: number
-    }) {
-        this.attributeToStat = {
-            [Attribute.Constitution]: con,
-            [Attribute.Strength]: str,
-            [Attribute.Dexterity]: dex,
-            [Attribute.Wisdom]: wis,
-            [Attribute.Intelligence]: int,
-            [Attribute.Charisma]: cha,
-        };
+    constructor() {
+        this.attributeToStat = {} as Record<Attribute, number>;
+        for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
+            this.attributeToStat[attribute] = 0;
+        }
     }
 
     get(attribute: Attribute) : number {

--- a/src/base_game_enums.ts
+++ b/src/base_game_enums.ts
@@ -1,0 +1,35 @@
+// Note, the name for this file is pretty arbitrary, it could be named better
+export enum Attribute {
+    Constitution,
+    Strength,
+    Dexterity,
+    Wisdom,
+    Intelligence,
+    Charisma,
+}
+
+export enum AttackType {
+    Strike,
+    Projectile,
+    Curse,
+}
+
+export enum EvasiveStatType {
+    Fortitude,
+    Reflex,
+    Willpower,
+}
+
+export enum DamageType {
+    Slashing,
+    Bludgeoning,
+    Piercing,
+    Fire,
+    Water,
+    Air,
+    Earth,
+    Poison,
+    Radiant,
+    Necrotic,
+    Psychic,
+}

--- a/src/character.ts
+++ b/src/character.ts
@@ -1,0 +1,24 @@
+import { AttributeStats } from 'attribute_stats';
+import { Attribute, AttackType, DamageType } from 'base_game_enums';
+import { ResistanceStats } from 'resistance_stats';
+
+// This is here for now since there's not much special about weapons (yet)
+export interface Weapon {
+    attribute: Attribute;
+    attackType: AttackType;
+    toHitMultiplier: number;
+    difficultyClass: number;
+    damageType: DamageType;
+}
+
+export class Character {
+    attributeStats: AttributeStats;
+    resistanceStats: ResistanceStats;
+    weapon: Weapon;
+
+    constructor(attrStats: AttributeStats, resStats: ResistanceStats, weap: Weapon) {
+        this.attributeStats = attrStats;
+        this.resistanceStats = resStats;
+        this.weapon = weap;
+    }
+}

--- a/src/resistance_stats.ts
+++ b/src/resistance_stats.ts
@@ -1,18 +1,5 @@
+import { DamageType } from 'base_game_enums';
 import { enumerateEnumValues } from 'utils';
-
-export enum DamageType {
-    Slashing,
-    Bludgeoning,
-    Piercing,
-    Fire,
-    Water,
-    Air,
-    Earth,
-    Poison,
-    Radiant,
-    Necrotic,
-    Psychic,
-}
 
 export interface ResistanceStat {
     percent: number;

--- a/src/tests/attack_calculator.test.ts
+++ b/src/tests/attack_calculator.test.ts
@@ -1,7 +1,6 @@
-import {
-    AttributeStats, Character, calculateToHit, calculateDamage, Weapon, Attribute, AttackType
-} from 'attack_calculator';
-import { DamageType, ResistanceStats } from 'resistance_stats';
+import { AttributeStats, Character, calculateToHit, calculateDamage, Weapon } from 'attack_calculator';
+import { Attribute, AttackType, DamageType } from 'base_game_enums';
+import { ResistanceStats } from 'resistance_stats';
 import { enumerateEnumValues } from 'utils';
 
 let attackerAttrStats: AttributeStats, attackerWeapon: Weapon, attacker: Character;
@@ -69,11 +68,11 @@ describe('toHit and evade calculation is correct', () => {
     });
 
     test('attacker stat changes attackerToHit', () => {
-        attacker.attributeStats.setAttribute(Attribute.Dexterity, 12);
+        attacker.attributeStats.set(Attribute.Dexterity, 12);
         const resultsDex12 = calculateToHit(1, attacker, defender);
         expect(resultsDex12.attackerToHit).toBe(14);  // 12 * 1.25 - 2 + 1
 
-        attacker.attributeStats.setAttribute(Attribute.Dexterity, 16);
+        attacker.attributeStats.set(Attribute.Dexterity, 16);
         const resultsDex16 = calculateToHit(1, attacker, defender);
         expect(resultsDex16.attackerToHit).toBe(19);  // 16 * 1.25 - 2 + 1
 
@@ -105,18 +104,18 @@ describe('toHit and evade calculation is correct', () => {
     });
 
     test('defender stat changes defenderEvade', () => {
-        defender.attributeStats.setAttribute(Attribute.Constitution, 15);
-        defender.attributeStats.setAttribute(Attribute.Strength, 14);
+        defender.attributeStats.set(Attribute.Constitution, 15);
+        defender.attributeStats.set(Attribute.Strength, 14);
         const resultsCon15Str14 = calculateToHit(1, attacker, defender);
         expect(resultsCon15Str14.defenderEvade).toBe(22);  // ceil(0.75 * (15 + 14))
 
-        defender.attributeStats.setAttribute(Attribute.Constitution, 20);
-        defender.attributeStats.setAttribute(Attribute.Strength, 14);
+        defender.attributeStats.set(Attribute.Constitution, 20);
+        defender.attributeStats.set(Attribute.Strength, 14);
         const resultsCon20Str14 = calculateToHit(1, attacker, defender);
         expect(resultsCon20Str14.defenderEvade).toBe(26);  // ceil(0.75 * (20 + 14))
 
-        defender.attributeStats.setAttribute(Attribute.Constitution, 15);
-        defender.attributeStats.setAttribute(Attribute.Strength, 20);
+        defender.attributeStats.set(Attribute.Constitution, 15);
+        defender.attributeStats.set(Attribute.Strength, 20);
         const resultsCon15Str20 = calculateToHit(1, attacker, defender);
         expect(resultsCon15Str20.defenderEvade).toBe(27);  // ceil(0.75 * (15 + 20))
 
@@ -130,7 +129,7 @@ describe('stats used by toHit calculation are correct', () => {
         function resetAndTestForAttribute(attribute: Attribute) {
             resetValues();
             attacker.weapon.attribute = attribute;
-            attacker.attributeStats.setAttribute(attribute, 20);
+            attacker.attributeStats.set(attribute, 20);
 
             const results = calculateToHit(1, attacker, defender);
             expect(results.attackerToHit).toBe(24);  // 20 * 1.25 - 2 + 1
@@ -147,8 +146,8 @@ describe('stats used by toHit calculation are correct', () => {
             attackType: AttackType, attribute1: Attribute, attribute2: Attribute) {
             resetValues();
             attacker.weapon.attackType = attackType;
-            defender.attributeStats.setAttribute(attribute1, 20);
-            defender.attributeStats.setAttribute(attribute2, 20);
+            defender.attributeStats.set(attribute1, 20);
+            defender.attributeStats.set(attribute2, 20);
 
             const results = calculateToHit(1, attacker, defender);
             expect(results.attackerToHit).toBe(14);  // 12 * 1.25 - 2 + 1
@@ -166,7 +165,7 @@ describe('damage calculation is correct', () => {
         function resetAndTestForAttribute(attribute: Attribute) {
             resetValues();
             attacker.weapon.attribute = attribute;
-            attacker.attributeStats.setAttribute(attribute, 15);
+            attacker.attributeStats.set(attribute, 15);
 
             expect(calculateDamage(attacker, defender)).toBe(15);
         }
@@ -181,7 +180,7 @@ describe('damage calculation is correct', () => {
             resetValues();
             attacker.weapon.damageType = damageType;
             attacker.weapon.attribute = Attribute.Charisma;
-            attacker.attributeStats.setAttribute(Attribute.Charisma, 15);
+            attacker.attributeStats.set(Attribute.Charisma, 15);
 
             defender.resistanceStats.set(damageType, {percent: 0.25, flat: 0});
 
@@ -198,7 +197,7 @@ describe('damage calculation is correct', () => {
             resetValues();
             attacker.weapon.damageType = damageType;
             attacker.weapon.attribute = Attribute.Charisma;
-            attacker.attributeStats.setAttribute(Attribute.Charisma, 15);
+            attacker.attributeStats.set(Attribute.Charisma, 15);
 
             defender.resistanceStats.set(damageType, {percent: 0, flat: 5});
 
@@ -216,7 +215,7 @@ describe('damage calculation is correct', () => {
             resetValues();
             attacker.weapon.damageType = damageType;
             attacker.weapon.attribute = Attribute.Charisma;
-            attacker.attributeStats.setAttribute(Attribute.Charisma, 15);
+            attacker.attributeStats.set(Attribute.Charisma, 15);
 
             defender.resistanceStats.set(damageType, {percent: 0.25, flat: 5});
 
@@ -232,7 +231,7 @@ describe('damage calculation is correct', () => {
     test('damage minimum is 1', () => {
         attacker.weapon.damageType = DamageType.Piercing;
         attacker.weapon.attribute = Attribute.Charisma;
-        attacker.attributeStats.setAttribute(Attribute.Charisma, 15);
+        attacker.attributeStats.set(Attribute.Charisma, 15);
 
         defender.resistanceStats.set(DamageType.Piercing, {percent: 1, flat: 0});
 

--- a/src/tests/attack_calculator.test.ts
+++ b/src/tests/attack_calculator.test.ts
@@ -1,5 +1,7 @@
-import { AttributeStats, Character, calculateToHit, calculateDamage, Weapon } from 'attack_calculator';
+import { calculateToHit, calculateDamage } from 'attack_calculator';
+import { AttributeStats } from 'attribute_stats';
 import { Attribute, AttackType, DamageType } from 'base_game_enums';
+import { Weapon, Character } from 'character';
 import { ResistanceStats } from 'resistance_stats';
 import { enumerateEnumValues } from 'utils';
 

--- a/src/tests/attack_calculator.test.ts
+++ b/src/tests/attack_calculator.test.ts
@@ -1,39 +1,31 @@
 import { calculateToHit, calculateDamage } from 'attack_calculator';
 import { AttributeStats } from 'attribute_stats';
 import { Attribute, AttackType, DamageType } from 'base_game_enums';
-import { Weapon, Character } from 'character';
+import { Character } from 'character';
 import { ResistanceStats } from 'resistance_stats';
 import { enumerateEnumValues } from 'utils';
 
-let attackerAttrStats: AttributeStats, attackerWeapon: Weapon, attacker: Character;
-let defenderAttrStats: AttributeStats, defenderWeapon: Weapon, defender: Character;
+let attacker: Character;
+let defender: Character;
 
 function resetValues() {
-    attackerAttrStats = new AttributeStats({
-        con: 10, str: 11, dex: 12, wis: 13, int: 14, cha: 15,
-    });
-    attackerWeapon = {
+    // These are set to "identity" values (i.e. 0 for adding, 1 for multiplying) for ease of reasoning in tests
+    const attackerAttrStats = new AttributeStats();
+    const attackerWeapon = {
         attribute: Attribute.Dexterity,
         attackType: AttackType.Strike,
-        toHitMultiplier: 1.25,
-        difficultyClass: 2,
+        toHitMultiplier: 1,
+        difficultyClass: 0,
         damageType: DamageType.Piercing,
     };
     attacker = new Character(attackerAttrStats, new ResistanceStats(), attackerWeapon);
 
-    defenderAttrStats = new AttributeStats({
-        con: 15,
-        str: 14,
-        dex: 13,
-        wis: 12,
-        int: 11,
-        cha: 10,
-    });
-    defenderWeapon = {
+    const defenderAttrStats = new AttributeStats();
+    const defenderWeapon = {
         attribute: Attribute.Dexterity,
         attackType: AttackType.Strike,
-        toHitMultiplier: 1.25,
-        difficultyClass: 2,
+        toHitMultiplier: 1,
+        difficultyClass: 0,
         damageType: DamageType.Piercing,
     };
     defender = new Character(defenderAttrStats, new ResistanceStats(), defenderWeapon);
@@ -44,188 +36,138 @@ beforeEach(resetValues);
 describe('doesAttackHit is correct', () => {
     test('attackerToHit > defenderEvade', () => {
         const results = calculateToHit(15, attacker, defender);
-        expect(results.doesAttackHit).toBe(true);  // 12 * 1.25 - 2 + 15 > 0.75 * (15 + 14)
+        expect(results.doesAttackHit).toBe(true);
+        expect(results.attackerToHit).toBeGreaterThan(results.defenderEvade);
     });
 
+    // The test weapon attack type is strike, which maps to fortitude, which is calculated using str + con
     test('attackerToHit < defenderEvade', () => {
+        defender.attributeStats.set(Attribute.Strength, 5);
+
         const results = calculateToHit(1, attacker, defender);
-        expect(results.doesAttackHit).toBe(false);  // 12 * 1.25 - 2 + 1 < 0.75 * (15 + 14)
+        expect(results.doesAttackHit).toBe(false);
+        expect(results.attackerToHit).toBeLessThan(results.defenderEvade);
     });
 
     test('attackerToHit == defenderEvade', () => {
-        const results = calculateToHit(9, attacker, defender);
-        expect(results.doesAttackHit).toBe(true);  // 12 * 1.25 - 2 + 9 == 0.75 * (15 + 14)
+        defender.attributeStats.set(Attribute.Strength, 1);
+
+        const results = calculateToHit(1, attacker, defender);
+        expect(results.doesAttackHit).toBe(true);
+        expect(results.attackerToHit).toBe(results.defenderEvade);
     });
 });
 
 describe('toHit and evade calculation is correct', () => {
     test('roll changes attackerToHit', () => {
-        const resultsRoll1 = calculateToHit(1, attacker, defender);
-        expect(resultsRoll1.attackerToHit).toBe(14);  // 12 * 1.25 - 2 + 1
-
-        const resultsRoll2 = calculateToHit(2, attacker, defender);
-        expect(resultsRoll2.attackerToHit).toBe(15);  // 12 * 1.25 - 2 + 2
-
-        expect(resultsRoll1.defenderEvade).toBe(resultsRoll2.defenderEvade);
+        expect(calculateToHit(2, attacker, defender).attackerToHit).toBe(2);
     });
 
     test('attacker stat changes attackerToHit', () => {
-        attacker.attributeStats.set(Attribute.Dexterity, 12);
-        const resultsDex12 = calculateToHit(1, attacker, defender);
-        expect(resultsDex12.attackerToHit).toBe(14);  // 12 * 1.25 - 2 + 1
-
-        attacker.attributeStats.set(Attribute.Dexterity, 16);
-        const resultsDex16 = calculateToHit(1, attacker, defender);
-        expect(resultsDex16.attackerToHit).toBe(19);  // 16 * 1.25 - 2 + 1
-
-        expect(resultsDex12.defenderEvade).toBe(resultsDex16.defenderEvade);
+        attacker.attributeStats.set(attacker.weapon.attribute, 12);
+        expect(calculateToHit(1, attacker, defender).attackerToHit).toBe(13);  // 12 + 1
     });
 
     test('weapToHitMultiplier changes attackerToHit', () => {
-        attacker.weapon.toHitMultiplier = 1.25;
-        const resultsMult125 = calculateToHit(1, attacker, defender);
-        expect(resultsMult125.attackerToHit).toBe(14);  // 12 * 1.25 - 2 + 1
-
+        attacker.attributeStats.set(attacker.weapon.attribute, 12);
         attacker.weapon.toHitMultiplier = 1.4;
-        const resultsMult14 = calculateToHit(1, attacker, defender);
-        expect(resultsMult14.attackerToHit).toBe(16);  // ceil(12 * 1.4 - 2 + 1)
-
-        expect(resultsMult125.defenderEvade).toBe(resultsMult14.defenderEvade);
+        expect(calculateToHit(1, attacker, defender).attackerToHit).toBe(18);  // ceil(12 * 1.4) + 1
     });
 
     test('weapDifficultyClass changes attackerToHit', () => {
         attacker.weapon.difficultyClass = 2;
-        const resultsDc2 = calculateToHit(1, attacker, defender);
-        expect(resultsDc2.attackerToHit).toBe(14);  // 12 * 1.25 - 2 + 1
-
-        attacker.weapon.difficultyClass = 0;
-        const resultsDc0 = calculateToHit(1, attacker, defender);
-        expect(resultsDc0.attackerToHit).toBe(16);  // 12 * 1.25 - 0 + 1
-
-        expect(resultsDc2.defenderEvade).toBe(resultsDc0.defenderEvade);
+        expect(calculateToHit(5, attacker, defender).attackerToHit).toBe(3);  // 5 - 2
     });
 
     test('defender stat changes defenderEvade', () => {
         defender.attributeStats.set(Attribute.Constitution, 15);
         defender.attributeStats.set(Attribute.Strength, 14);
-        const resultsCon15Str14 = calculateToHit(1, attacker, defender);
-        expect(resultsCon15Str14.defenderEvade).toBe(22);  // ceil(0.75 * (15 + 14))
-
-        defender.attributeStats.set(Attribute.Constitution, 20);
-        defender.attributeStats.set(Attribute.Strength, 14);
-        const resultsCon20Str14 = calculateToHit(1, attacker, defender);
-        expect(resultsCon20Str14.defenderEvade).toBe(26);  // ceil(0.75 * (20 + 14))
-
-        defender.attributeStats.set(Attribute.Constitution, 15);
-        defender.attributeStats.set(Attribute.Strength, 20);
-        const resultsCon15Str20 = calculateToHit(1, attacker, defender);
-        expect(resultsCon15Str20.defenderEvade).toBe(27);  // ceil(0.75 * (15 + 20))
-
-        expect(resultsCon15Str14.attackerToHit).toBe(resultsCon20Str14.attackerToHit);
-        expect(resultsCon20Str14.attackerToHit).toBe(resultsCon15Str20.attackerToHit);
+        expect(calculateToHit(1, attacker, defender).defenderEvade).toBe(22);  // ceil(0.75 * (15 + 14))
     });
 });
 
 describe('stats used by toHit calculation are correct', () => {
     test('weapon attribute changes attackerToHit', () => {
-        function resetAndTestForAttribute(attribute: Attribute) {
+        for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
             resetValues();
             attacker.weapon.attribute = attribute;
             attacker.attributeStats.set(attribute, 20);
 
             const results = calculateToHit(1, attacker, defender);
-            expect(results.attackerToHit).toBe(24);  // 20 * 1.25 - 2 + 1
-            expect(results.defenderEvade).toBe(22);  // ceil(0.75 * (15 + 14))
-        }
-
-        for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
-            resetAndTestForAttribute(attribute);
+            expect(results.attackerToHit).toBe(21);  // 20 + 1
+            expect(results.defenderEvade).toBe(0);  // unaffected from initial 0 value
         }
     });
 
     test('weapon attack type changes defender evade', () => {
-        function resetAndTestForAttackTypeAndAttributes(
+        function resetAndTest(
             attackType: AttackType, attribute1: Attribute, attribute2: Attribute) {
             resetValues();
+
             attacker.weapon.attackType = attackType;
             defender.attributeStats.set(attribute1, 20);
             defender.attributeStats.set(attribute2, 20);
 
             const results = calculateToHit(1, attacker, defender);
-            expect(results.attackerToHit).toBe(14);  // 12 * 1.25 - 2 + 1
+            expect(results.attackerToHit).toBe(1);  // 0 stats + 1 for the roll
             expect(results.defenderEvade).toBe(30);  // 0.75 * (20 + 20)
         }
 
-        resetAndTestForAttackTypeAndAttributes(AttackType.Strike, Attribute.Constitution, Attribute.Strength);
-        resetAndTestForAttackTypeAndAttributes(AttackType.Projectile, Attribute.Dexterity, Attribute.Wisdom);
-        resetAndTestForAttackTypeAndAttributes(AttackType.Curse, Attribute.Intelligence, Attribute.Charisma);
+        resetAndTest(AttackType.Strike, Attribute.Constitution, Attribute.Strength);
+        resetAndTest(AttackType.Projectile, Attribute.Dexterity, Attribute.Wisdom);
+        resetAndTest(AttackType.Curse, Attribute.Intelligence, Attribute.Charisma);
     });
 });
 
 describe('damage calculation is correct', () => {
     test('weapon attribute changes damage', () => {
-        function resetAndTestForAttribute(attribute: Attribute) {
+        for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
             resetValues();
+
             attacker.weapon.attribute = attribute;
             attacker.attributeStats.set(attribute, 15);
 
             expect(calculateDamage(attacker, defender)).toBe(15);
         }
-
-        for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
-            resetAndTestForAttribute(attribute);
-        }
     });
 
     test('defender percentage res changes damage', () => {
-        function resetAndTestForPercentRes(damageType: DamageType) {
+        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
             resetValues();
+
             attacker.weapon.damageType = damageType;
             attacker.weapon.attribute = Attribute.Charisma;
             attacker.attributeStats.set(Attribute.Charisma, 15);
-
             defender.resistanceStats.set(damageType, {percent: 0.25, flat: 0});
 
             expect(calculateDamage(attacker, defender)).toBe(12);  // ceil(15 * 0.75) = 12
         }
-
-        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-            resetAndTestForPercentRes(damageType);
-        }
     });
 
     test('defender flat res changes damage', () => {
-        function resetAndTestForPercentRes(damageType: DamageType) {
+        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
             resetValues();
+
             attacker.weapon.damageType = damageType;
             attacker.weapon.attribute = Attribute.Charisma;
             attacker.attributeStats.set(Attribute.Charisma, 15);
-
             defender.resistanceStats.set(damageType, {percent: 0, flat: 5});
 
             expect(calculateDamage(attacker, defender)).toBe(10);
-        }
-
-        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-            resetAndTestForPercentRes(damageType);
         }
     });
 
     // Not sure if this is correct, but in either case there should be a test for it/ the ceil
     test('defender percent res applied before flat res', () => {
-        function resetAndTestForPercentRes(damageType: DamageType) {
+        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
             resetValues();
+
             attacker.weapon.damageType = damageType;
             attacker.weapon.attribute = Attribute.Charisma;
             attacker.attributeStats.set(Attribute.Charisma, 15);
-
             defender.resistanceStats.set(damageType, {percent: 0.25, flat: 5});
 
             expect(calculateDamage(attacker, defender)).toBe(7);  // ceil(15 * 0.75) - 5. ceil((15 - 5) * 0.75) = 8
-        }
-
-        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-            resetAndTestForPercentRes(damageType);
         }
     });
 
@@ -234,7 +176,6 @@ describe('damage calculation is correct', () => {
         attacker.weapon.damageType = DamageType.Piercing;
         attacker.weapon.attribute = Attribute.Charisma;
         attacker.attributeStats.set(Attribute.Charisma, 15);
-
         defender.resistanceStats.set(DamageType.Piercing, {percent: 1, flat: 0});
 
         expect(calculateDamage(attacker, defender)).toBe(1);

--- a/src/tests/attribute_stats.test.ts
+++ b/src/tests/attribute_stats.test.ts
@@ -1,0 +1,10 @@
+import { AttributeStats } from 'attribute_stats';
+import { Attribute } from 'base_game_enums';
+import { enumerateEnumValues } from 'utils';
+
+test('All stats initialized to 0 if none passed in', () => {
+    const attributeStats = new AttributeStats();
+    for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
+        expect(attributeStats.get(attribute)).toBe(0);
+    }
+});

--- a/src/tests/resistance_stats.test.ts
+++ b/src/tests/resistance_stats.test.ts
@@ -2,40 +2,30 @@ import { DamageType } from 'base_game_enums';
 import { ResistanceStats } from 'resistance_stats';
 import { enumerateEnumValues } from 'utils';
 
-describe('ResistanceStats tests', () => {
-    test('All stats initialized to 0 if none passed in', () => {
-        const resistanceStats = new ResistanceStats();
-        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-            expect(resistanceStats.get(damageType)).toStrictEqual({percent: 0, flat: 0});
-        }
+test('All stats initialized to 0 if none passed in', () => {
+    const resistanceStats = new ResistanceStats();
+    for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
+        expect(resistanceStats.get(damageType)).toStrictEqual({percent: 0, flat: 0});
+    }
+});
+
+test('Stats initialized if passed in', () => {
+    const resistanceStats = new ResistanceStats({
+        [DamageType.Bludgeoning]: {percent: 0.1, flat: 15},
+        [DamageType.Fire]: {percent: 0.2, flat: 25}
     });
 
-    test('Stats initialized if passed in', () => {
-        const resistanceStats = new ResistanceStats({
-            [DamageType.Bludgeoning]: {percent: 0.1, flat: 15},
-            [DamageType.Fire]: {percent: 0.2, flat: 25}
-        });
-
-        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-            const resistanceStat = resistanceStats.get(damageType);
-            switch (damageType) {
-                case DamageType.Bludgeoning:
-                    expect(resistanceStat).toStrictEqual({percent: 0.1, flat: 15});
-                    continue;
-                case DamageType.Fire:
-                    expect(resistanceStat).toStrictEqual({percent: 0.2, flat: 25});
-                    continue;
-                default:
-                    expect(resistanceStat).toStrictEqual({percent: 0, flat: 0});
-            }
+    for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
+        const resistanceStat = resistanceStats.get(damageType);
+        switch (damageType) {
+            case DamageType.Bludgeoning:
+                expect(resistanceStat).toStrictEqual({percent: 0.1, flat: 15});
+                continue;
+            case DamageType.Fire:
+                expect(resistanceStat).toStrictEqual({percent: 0.2, flat: 25});
+                continue;
+            default:
+                expect(resistanceStat).toStrictEqual({percent: 0, flat: 0});
         }
-    });
-
-    test('set', () => {
-        for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-            const resistanceStats = new ResistanceStats();
-            resistanceStats.set(damageType, {percent: 0.5, flat: 5});
-            expect(resistanceStats.get(damageType)).toStrictEqual({percent: 0.5, flat: 5});
-        }
-    });
+    }
 });

--- a/src/tests/resistance_stats.test.ts
+++ b/src/tests/resistance_stats.test.ts
@@ -1,4 +1,5 @@
-import { DamageType, ResistanceStats } from 'resistance_stats';
+import { DamageType } from 'base_game_enums';
+import { ResistanceStats } from 'resistance_stats';
 import { enumerateEnumValues } from 'utils';
 
 describe('ResistanceStats tests', () => {


### PR DESCRIPTION
No real functionality changes, but the following cleanups:

- Consolidate all enums in `base_game_enums` (filename suggestions welcome)
- Move `AttributeStats` class to its own file, and refactor to be similar to `ResistanceStats`
- Make `AttributeStats` initialize everything to 0
- In attack calc tests, initialize everything to "identity" when possible, which makes numbers easier to reason about