### PR TITLE
Weapon Multiplier + Base Damage

### DIFF
--- a/src/attack_calculator.ts
+++ b/src/attack_calculator.ts
@@ -29,12 +29,9 @@ Not yet implemented for toHit:
 - Dual wield - toHit
  */
 export function calculateToHit(roll: number, attacker: Character, defender: Character) : ToHitResults {
-    const attackerWeaponAttributeToHit = Math.ceil(
-        attacker.attributeStats.get(attacker.weapon.attribute) *
-        attacker.weapon.toHitMultiplier
-    );
-    const attackerToHit = attackerWeaponAttributeToHit - attacker.weapon.difficultyClass + roll;
-
+    // Note that some of these (and in calculateDamage) could probably go on the Character class instead, and might
+    // make the testing story a tad cleaner
+    const attackerToHit = attacker.getScalingFactor() - attacker.weapon.difficultyClass + roll;
     const defenderEvasiveStatType = getEvasiveStatTypeForAttackType(attacker.weapon.attackType);
     const defenderEvade = defender.attributeStats.getEvasiveStat(defenderEvasiveStatType);
 
@@ -52,8 +49,8 @@ Not yet implemented for damage:
 - Two handing weapon multiplier
 */
 export function calculateDamage(attacker: Character, defender: Character) : number {
-    const atkWeapStat = attacker.attributeStats.get(attacker.weapon.attribute);
-    const defAttrRes = defender.resistanceStats.get(attacker.weapon.damageType);
-    const calcDmg = Math.ceil(atkWeapStat * (1 - defAttrRes.percent)) - defAttrRes.flat;
+    const attackerDamage = attacker.getScalingFactor() + attacker.weapon.baseDamage;
+    const defenderRes = defender.resistanceStats.get(attacker.weapon.damageType);
+    const calcDmg = Math.ceil(attackerDamage * (1 - defenderRes.percent)) - defenderRes.flat;
     return Math.max(calcDmg, 1);
 }

--- a/src/character.ts
+++ b/src/character.ts
@@ -4,11 +4,13 @@ import { ResistanceStats } from 'resistance_stats';
 
 // This is here for now since there's not much special about weapons (yet)
 export interface Weapon {
+    // Note that there can be multiple attributes here (and one multiplier per attribute), it's just not implemented yet
     attribute: Attribute;
     attackType: AttackType;
-    toHitMultiplier: number;
-    difficultyClass: number;
     damageType: DamageType;
+    baseDamage: number;
+    attributeMultiplier: number;
+    difficultyClass: number;
 }
 
 export class Character {
@@ -20,5 +22,12 @@ export class Character {
         this.attributeStats = attrStats;
         this.resistanceStats = resStats;
         this.weapon = weap;
+    }
+
+    getScalingFactor() : number {
+        return Math.ceil(
+            this.attributeStats.get(this.weapon.attribute) *
+            this.weapon.attributeMultiplier
+        );
     }
 }

--- a/src/tests/attack_calculator.test.ts
+++ b/src/tests/attack_calculator.test.ts
@@ -14,9 +14,10 @@ function resetValues() {
     const attackerWeapon = {
         attribute: Attribute.Dexterity,
         attackType: AttackType.Strike,
-        toHitMultiplier: 1,
-        difficultyClass: 0,
         damageType: DamageType.Piercing,
+        baseDamage: 0,
+        attributeMultiplier: 1,
+        difficultyClass: 0,
     };
     attacker = new Character(attackerAttrStats, new ResistanceStats(), attackerWeapon);
 
@@ -24,9 +25,10 @@ function resetValues() {
     const defenderWeapon = {
         attribute: Attribute.Dexterity,
         attackType: AttackType.Strike,
-        toHitMultiplier: 1,
-        difficultyClass: 0,
         damageType: DamageType.Piercing,
+        baseDamage: 0,
+        attributeMultiplier: 1,
+        difficultyClass: 0,
     };
     defender = new Character(defenderAttrStats, new ResistanceStats(), defenderWeapon);
 }
@@ -70,7 +72,7 @@ describe('toHit and evade calculation is correct', () => {
 
     test('weapToHitMultiplier changes attackerToHit', () => {
         attacker.attributeStats.set(attacker.weapon.attribute, 12);
-        attacker.weapon.toHitMultiplier = 1.4;
+        attacker.weapon.attributeMultiplier = 1.4;
         expect(calculateToHit(1, attacker, defender).attackerToHit).toBe(18);  // ceil(12 * 1.4) + 1
     });
 
@@ -129,6 +131,34 @@ describe('damage calculation is correct', () => {
 
             expect(calculateDamage(attacker, defender)).toBe(15);
         }
+    });
+
+    test('weapon baseDamage changes damage', () => {
+        attacker.weapon.damageType = DamageType.Piercing;
+        attacker.weapon.attribute = Attribute.Charisma;
+        attacker.weapon.baseDamage = 5;
+        attacker.attributeStats.set(Attribute.Charisma, 15);
+
+        expect(calculateDamage(attacker, defender)).toBe(20);  // 5 + 15 = 12
+    });
+
+    test('weapon attributeMultiplier changes damage', () => {
+        attacker.weapon.damageType = DamageType.Piercing;
+        attacker.weapon.attribute = Attribute.Charisma;
+        attacker.weapon.attributeMultiplier = 1.25;
+        attacker.attributeStats.set(Attribute.Charisma, 15);
+
+        expect(calculateDamage(attacker, defender)).toBe(19);  // ceil(1.25 * 15) = 19
+    });
+
+    test('weapon attributeMultiplier applied before baseDamage', () => {
+        attacker.weapon.damageType = DamageType.Piercing;
+        attacker.weapon.attribute = Attribute.Charisma;
+        attacker.weapon.attributeMultiplier = 1.25;
+        attacker.weapon.baseDamage = 5;
+        attacker.attributeStats.set(Attribute.Charisma, 15);
+
+        expect(calculateDamage(attacker, defender)).toBe(24);  // ceil(1.25 * 15) + 5 = 24. ceil(1.25 * (15 + 5)) = 25
     });
 
     test('defender percentage res changes damage', () => {


### PR DESCRIPTION
Turns out that both damage and toHit are based off of "scaling factor". Damage is also based off a "base damage" value that lives on the weapon.

Implements these changes, and adds a few notes.