### PR TITLE
Changes to support new google sheet

### DIFF
--- a/src/attribute_stats.ts
+++ b/src/attribute_stats.ts
@@ -1,4 +1,4 @@
-import { Attribute, EvasiveStatType, getAttrAbbreviation } from 'base_game_enums';
+import { Attribute, EvasiveStatType, getAbbrevFromAttr } from 'base_game_enums';
 import { enumerateEnumValues, getNonNull } from 'utils';
 
 export class AttributeStats {
@@ -11,7 +11,7 @@ export class AttributeStats {
     static buildFromMap(map: Map<string, any>) : AttributeStats {
         const attributeToStat = {} as Record<Attribute, number>;
         for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
-            attributeToStat[attribute] = getNonNull(map.get(getAttrAbbreviation(attribute)));
+            attributeToStat[attribute] = getNonNull(map.get(getAbbrevFromAttr(attribute)));
         }
 
         return new AttributeStats(attributeToStat);

--- a/src/attribute_stats.ts
+++ b/src/attribute_stats.ts
@@ -1,5 +1,5 @@
-import { Attribute, EvasiveStatType } from 'base_game_enums';
-import { enumerateEnumValues } from 'utils';
+import { Attribute, EvasiveStatType, getAttrAbbreviation } from 'base_game_enums';
+import { enumerateEnumValues, getNonNull } from 'utils';
 
 export class AttributeStats {
     attributeToStat: Record<Attribute, number>;
@@ -8,10 +8,10 @@ export class AttributeStats {
         this.attributeToStat = attributeToStat;
     }
 
-    static buildEmpty() : AttributeStats {
+    static buildFromMap(map: Map<string, any>) : AttributeStats {
         const attributeToStat = {} as Record<Attribute, number>;
         for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
-            attributeToStat[attribute] = 0;
+            attributeToStat[attribute] = getNonNull(map.get(getAttrAbbreviation(attribute)));
         }
 
         return new AttributeStats(attributeToStat);

--- a/src/attribute_stats.ts
+++ b/src/attribute_stats.ts
@@ -17,35 +17,6 @@ export class AttributeStats {
         return new AttributeStats(attributeToStat);
     }
 
-    static buildUsingSheet(name:string) : AttributeStats {
-        const attributeToStat = {} as Record<Attribute, number>;
-        let sheet = SpreadsheetApp.getActive().getSheetByName('Units');
-        if (sheet != null) {
-            let data = sheet.getDataRange().getValues();
-            let row: number = -1;
-
-            // find the row that matches the name
-            for (let i = 0; i < data.length; i++) {
-                if (data[i][0] === name) {
-                    row = i;
-                    break;
-                }
-            }
-
-            if (row === -1) {
-                // Name not found
-                throw ('Name not found');
-            }
-
-            for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
-                console.log(Attribute[attribute] + ': ' + data[row][attribute + 1]);
-                attributeToStat[attribute] = data[row][attribute + 1];
-            }
-        }
-
-        return new AttributeStats(attributeToStat);
-    }
-
     get(attribute: Attribute) : number {
         return this.attributeToStat[attribute];
     }

--- a/src/base_game_enums.ts
+++ b/src/base_game_enums.ts
@@ -8,6 +8,23 @@ export enum Attribute {
     Charisma,
 }
 
+export function getAttrAbbreviation(attr: Attribute) : string {
+    switch (attr) {
+        case Attribute.Constitution:
+            return 'CON';
+        case Attribute.Strength:
+            return 'STR';
+        case Attribute.Dexterity:
+            return 'DEX';
+        case Attribute.Wisdom:
+            return 'WIS';
+        case Attribute.Intelligence:
+            return 'INT';
+        case Attribute.Charisma:
+            return 'CHAR';
+    }
+}
+
 export enum AttackType {
     Strike,
     Projectile,

--- a/src/base_game_enums.ts
+++ b/src/base_game_enums.ts
@@ -8,7 +8,7 @@ export enum Attribute {
     Charisma,
 }
 
-export function getAttrAbbreviation(attr: Attribute) : string {
+export function getAbbrevFromAttr(attr: Attribute) : string {
     switch (attr) {
         case Attribute.Constitution:
             return 'CON';
@@ -22,6 +22,29 @@ export function getAttrAbbreviation(attr: Attribute) : string {
             return 'INT';
         case Attribute.Charisma:
             return 'CHAR';
+
+        default:
+            throw `Unknown attribute ${attr}`;
+    }
+}
+
+export function getAttrFromAbbrev(abbrev: string) : Attribute {
+    switch (abbrev) {
+        case 'CON':
+            return Attribute.Constitution;
+        case 'STR':
+            return Attribute.Strength;
+        case 'DEX':
+            return Attribute.Dexterity;
+        case 'WIS':
+            return Attribute.Wisdom;
+        case 'INT':
+            return Attribute.Intelligence;
+        case 'CHAR':
+            return Attribute.Charisma;
+
+        default:
+            throw `Unknown abbrev ${abbrev}`;
     }
 }
 

--- a/src/character.ts
+++ b/src/character.ts
@@ -18,8 +18,10 @@ export class Character {
         this.profile = prof;
     }
 
-    static buildUsingSheet(unitName: string, profileName: string) : Character {
+    // In the future we will be loading a profile as well, for simplicity in sheets the profile info lives on the unit
+    static buildUsingSheet(unitName: string) : Character {
         const attributeStats = AttributeStats.buildUsingSheet(unitName);
+        // armor
         const profile = Profile.buildFromSheet(profileName);
         const resistanceStats = ResistanceStats.buildUsingSheet(profile.armor);
         const dagger : Weapon = {  // placeholder

--- a/src/character.ts
+++ b/src/character.ts
@@ -15,26 +15,7 @@ export class Character {
         this.attributeStats = attrStats;
         this.resistanceStats = resStats;
         this.weapon = weap;
-        this.profile = prof;
-    }
-
-    // In the future we will be loading a profile as well, for simplicity in sheets the profile info lives on the unit
-    static buildUsingSheet(unitName: string) : Character {
-        const attributeStats = AttributeStats.buildUsingSheet(unitName);
-        // armor
-        const profile = Profile.buildFromSheet('');
-        const resistanceStats = ResistanceStats.buildUsingSheet(profile.armor);
-        const dagger : Weapon = {  // placeholder
-            attribute: Attribute.Dexterity,
-            attackType: AttackType.Strike,
-            damageType: DamageType.Piercing,
-            toHitMultiplier: 1,
-            damageMultiplier: 0.75,
-            difficultyClass: 2,
-            baseDamage: 2,
-        };
-
-        return new Character(attributeStats, resistanceStats, dagger, profile);
+        this.profile = prof;  // as of time of writing, unused in real code
     }
 
     // as of writing, unused and untested

--- a/src/character.ts
+++ b/src/character.ts
@@ -22,7 +22,7 @@ export class Character {
     static buildUsingSheet(unitName: string) : Character {
         const attributeStats = AttributeStats.buildUsingSheet(unitName);
         // armor
-        const profile = Profile.buildFromSheet(profileName);
+        const profile = Profile.buildFromSheet('');
         const resistanceStats = ResistanceStats.buildUsingSheet(profile.armor);
         const dagger : Weapon = {  // placeholder
             attribute: Attribute.Dexterity,

--- a/src/gsheets/loader.ts
+++ b/src/gsheets/loader.ts
@@ -1,0 +1,48 @@
+import { getNonNull } from 'utils';
+
+export function loadItem(sheetName: string, itemName: string, isRowIndexed: boolean) : Map<string, string> {
+    const sheet = getNonNull(SpreadsheetApp.getActive().getSheetByName(sheetName));
+
+    let data = sheet.getDataRange().getValues();
+
+    // as of writing, the armor sheet is the only column indexed sheet
+    if (!isRowIndexed) {
+        const numRows = data.length;
+        const numCols = data[0].length;
+
+        let dataTransposed: any[][] = new Array(numCols);
+        for (let i = 0; i < numCols; i++) {
+            dataTransposed[i] = new Array(numRows);
+        }
+
+        for (let i = 0; i < numRows; i++) {
+            for (let j = 0; j < numCols; j++) {
+                dataTransposed[j][i] = data[i][j];
+            }
+        }
+
+        data = dataTransposed;
+    }
+
+    let itemRowIndex: number = -1;
+    for (let rowNumber = 1; rowNumber < data.length; rowNumber++) {
+        if (data[rowNumber][0] === itemName) {
+            itemRowIndex = rowNumber;
+            break;
+        }
+    }
+
+    if (itemRowIndex === -1) {
+        throw 'Name not found';
+    }
+
+    const headerRow = data[0];
+    const itemRow = data[itemRowIndex];
+    const itemMap = new Map<string, string>();
+
+    for (let col = 0; col < headerRow.length; col++) {
+        itemMap.set(headerRow[col], itemRow[col]);
+    }
+
+    return itemMap;
+}

--- a/src/gsheets/loader.ts
+++ b/src/gsheets/loader.ts
@@ -1,6 +1,6 @@
 import { getNonNull } from 'utils';
 
-export function loadItem(sheetName: string, itemName: string, isRowIndexed: boolean) : Map<string, string> {
+export function loadItem(sheetName: string, itemName: string, isRowIndexed: boolean) : Map<string, any> {
     const sheet = getNonNull(SpreadsheetApp.getActive().getSheetByName(sheetName));
 
     let data = sheet.getDataRange().getValues();

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,11 @@ global.calculateAttack = () => {
     const attackerName = getNonNull(nameToRange.get('attacker')).getDisplayValue();
     const defenderName = getNonNull(nameToRange.get('defender')).getDisplayValue();
 
+    // AttrStats come from the Units tab
+    // Armor name comes from the Units tab. ResStats comes from the Armors tab (and is column-indexed)
+    // Weapon name comes from the Units tab. Weapon comes from the Weapons tab
+    // Profile is unused
+
     // load the attacker char
     Character.buildUsingSheet(attackerName,);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,26 @@
 import { calculateToHit, calculateDamage } from 'attack_calculator';
+import { AttributeStats } from 'attribute_stats';
+import { Skills } from 'base_game_enums';
 import { Character } from 'character';
 import { loadItem } from 'gsheets/loader';
+import { Profile } from 'profile';
+import { ResistanceStats } from 'resistance_stats';
 import { getNonNull, arrayToMap } from 'utils';
+
+function loadCharacter(characterName: string) : Character {
+    // As of time of writing, profile does not impact damage calculations. This will change in the future
+    const dummyProfile = new Profile({} as Record<Skills, number>, 0, 0, 0, '');
+
+    const unitMap = loadItem('Units', characterName, true);
+    const armorMap = loadItem('Armors', unitMap.get('Armor'), false);
+    const weaponMap = loadItem('Weapons', unitMap.get('Weapons'), true);
+
+    const attrStats = AttributeStats.buildFromMap(unitMap);
+    const resStats = ResistanceStats.buildFromMap(armorMap);
+    // TODO: weapon
+
+    return new Character(attrStats, resStats, {} as Weapon, dummyProfile);
+}
 
 // @ts-ignore
 global.calculateAttack = () => {
@@ -13,10 +32,7 @@ global.calculateAttack = () => {
     const attackerName = getNonNull(nameToRange.get('attacker')).getDisplayValue();
     const defenderName = getNonNull(nameToRange.get('defender')).getDisplayValue();
 
-    // AttrStats come from the Units tab
-    // Armor name comes from the Units tab. ResStats comes from the Armors tab (and is column-indexed)
-    // Weapon name comes from the Units tab. Weapon comes from the Weapons tab
-    // Profile is unused
+
 
     // load the attacker char
     Character.buildUsingSheet(attackerName,);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { calculateToHit, calculateDamage } from 'attack_calculator';
 import { Character } from 'character';
+import { loadItem } from 'gsheets/loader';
 import { getNonNull, arrayToMap } from 'utils';
 
 // @ts-ignore
@@ -13,6 +14,7 @@ global.calculateAttack = () => {
     const defenderName = getNonNull(nameToRange.get('defender')).getDisplayValue();
 
     // load the attacker char
+    Character.buildUsingSheet(attackerName,);
 
     // load the defender char
 
@@ -33,4 +35,17 @@ global.calculateAttack = () => {
     getNonNull(nameToRange.get('defenderEvade')).setValue(toHitResult.defenderEvade);
     getNonNull(nameToRange.get('didHit')).setValue(toHitResult.doesAttackHit);
     getNonNull(nameToRange.get('damage')).setValue(damage);
+};
+
+// @ts-ignore
+global.logLoading = () => {
+    loadItem('Units', 'Ixar', true).forEach((v, k) => {
+        console.log(`${k}: ${v}`);
+    });
+
+    console.log('');
+
+    loadItem('Armors', 'Iron', false).forEach((v, k) => {
+        console.log(`${k}: ${v}`);
+    });
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { loadItem } from 'gsheets/loader';
 import { Profile } from 'profile';
 import { ResistanceStats } from 'resistance_stats';
 import { getNonNull, arrayToMap } from 'utils';
+import { Weapon } from 'weapon';
 
 function loadCharacter(characterName: string) : Character {
     // As of time of writing, profile does not impact damage calculations. This will change in the future
@@ -15,11 +16,11 @@ function loadCharacter(characterName: string) : Character {
     const armorMap = loadItem('Armors', unitMap.get('Armor'), false);
     const weaponMap = loadItem('Weapons', unitMap.get('Weapons'), true);
 
-    const attrStats = AttributeStats.buildFromMap(unitMap);
-    const resStats = ResistanceStats.buildFromMap(armorMap);
-    // TODO: weapon
-
-    return new Character(attrStats, resStats, {} as Weapon, dummyProfile);
+    return new Character(
+        AttributeStats.buildFromMap(unitMap),
+        ResistanceStats.buildFromMap(armorMap),
+        Weapon.buildFromMap(weaponMap),
+        dummyProfile);
 }
 
 // @ts-ignore
@@ -32,41 +33,14 @@ global.calculateAttack = () => {
     const attackerName = getNonNull(nameToRange.get('attacker')).getDisplayValue();
     const defenderName = getNonNull(nameToRange.get('defender')).getDisplayValue();
 
+    const attacker = loadCharacter(attackerName);
+    const defender = loadCharacter(defenderName);
 
-
-    // load the attacker char
-    Character.buildUsingSheet(attackerName,);
-
-    // load the defender char
-
-    // const attacker = getNonNull(nameToChar.get(attackerName));
-    // const defender = getNonNull(nameToChar.get(defenderName));
-
-    // const toHitResult = calculateToHit(roll, attacker, defender);
-    // const damage = calculateDamage(attacker, defender);
-
-    const toHitResult = {
-        doesAttackHit: false,
-        attackerToHit: 4,
-        defenderEvade: 20,
-    };
-    const damage = 69;
+    const toHitResult = calculateToHit(roll, attacker, defender);
+    const damage = calculateDamage(attacker, defender);
 
     getNonNull(nameToRange.get('attackerToHit')).setValue(toHitResult.attackerToHit);
     getNonNull(nameToRange.get('defenderEvade')).setValue(toHitResult.defenderEvade);
     getNonNull(nameToRange.get('didHit')).setValue(toHitResult.doesAttackHit);
     getNonNull(nameToRange.get('damage')).setValue(damage);
-};
-
-// @ts-ignore
-global.logLoading = () => {
-    loadItem('Units', 'Ixar', true).forEach((v, k) => {
-        console.log(`${k}: ${v}`);
-    });
-
-    console.log('');
-
-    loadItem('Armors', 'Iron', false).forEach((v, k) => {
-        console.log(`${k}: ${v}`);
-    });
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,36 @@
-import { AttributeStats } from 'attribute_stats';
-
-function sayHi(person: string) {
-    // SpreadsheetApp.getUi().alert(`Hi ${person}`);
-    let character = AttributeStats.buildUsingSheet(person);
-}
+import { calculateToHit, calculateDamage } from 'attack_calculator';
+import { Character } from 'character';
+import { getNonNull, arrayToMap } from 'utils';
 
 // @ts-ignore
-global.calculateDamage = () => {
-    // const attrStats = new AttributeStats();
+global.calculateAttack = () => {
+    const SHEET_NAME = 'TestAttackCalc';
+    const sheet = getNonNull(SpreadsheetApp.getActive().getSheetByName(SHEET_NAME));
+    const nameToRange = arrayToMap(sheet.getNamedRanges(), nr => nr.getName(), nr => nr.getRange());
 
-    sayHi('Elmo Elless');
+    const roll = parseInt(getNonNull(nameToRange.get('roll')).getDisplayValue());
+    const attackerName = getNonNull(nameToRange.get('attacker')).getDisplayValue();
+    const defenderName = getNonNull(nameToRange.get('defender')).getDisplayValue();
+
+    // load the attacker char
+
+    // load the defender char
+
+    // const attacker = getNonNull(nameToChar.get(attackerName));
+    // const defender = getNonNull(nameToChar.get(defenderName));
+
+    // const toHitResult = calculateToHit(roll, attacker, defender);
+    // const damage = calculateDamage(attacker, defender);
+
+    const toHitResult = {
+        doesAttackHit: false,
+        attackerToHit: 4,
+        defenderEvade: 20,
+    };
+    const damage = 69;
+
+    getNonNull(nameToRange.get('attackerToHit')).setValue(toHitResult.attackerToHit);
+    getNonNull(nameToRange.get('defenderEvade')).setValue(toHitResult.defenderEvade);
+    getNonNull(nameToRange.get('didHit')).setValue(toHitResult.doesAttackHit);
+    getNonNull(nameToRange.get('damage')).setValue(damage);
 };

--- a/src/resistance_stats.ts
+++ b/src/resistance_stats.ts
@@ -1,5 +1,5 @@
 import { DamageType } from 'base_game_enums';
-import { enumerateEnumValues } from 'utils';
+import { enumerateEnumValues, getNonNull } from 'utils';
 
 export interface ResistanceStat {
     percent: number;
@@ -13,10 +13,14 @@ export class ResistanceStats {
         this.damageTypeToResistance = damageTypeToResistance;
     }
 
-    static buildEmpty() : ResistanceStats {
+    static buildFromMap(map: Map<string, any>) : ResistanceStats {
         const damageTypeToResistance = {} as Record<DamageType, ResistanceStat>;
         for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-            damageTypeToResistance[damageType] = {percent: 0, flat: 0};
+            const damageTypeStr = DamageType[damageType];
+            damageTypeToResistance[damageType] = {
+                percent: parseInt(getNonNull(map.get(`${damageTypeStr}%`))) / 100,
+                flat: parseInt(getNonNull(map.get(`${damageTypeStr} Flat`))),
+            };
         }
 
         return new ResistanceStats(damageTypeToResistance);

--- a/src/resistance_stats.ts
+++ b/src/resistance_stats.ts
@@ -26,37 +26,6 @@ export class ResistanceStats {
         return new ResistanceStats(damageTypeToResistance);
     }
 
-    static buildUsingSheet(armor: string) : ResistanceStats {
-        const damageTypeToResistance = {} as Record<DamageType, ResistanceStat>;
-        let sheet = SpreadsheetApp.getActive().getSheetByName('Armors');
-        if (sheet != null) {
-            let data = sheet.getDataRange().getValues();
-            let row: number = -1;
-
-            // find the row that matches the name
-            for (let i = 0; i < data.length; i++) {
-                if (data[i][0] === armor) {
-                    row = i;
-                    break;
-                }
-            }
-
-            if (row === -1) {
-                // Name not found
-                throw 'Name not found';
-            }
-
-            const damageTypes = enumerateEnumValues<DamageType>(DamageType);
-            for (const damageType of damageTypes) {
-                damageTypeToResistance[damageType] = {
-                    percent: data[row][damageType + 1],
-                    flat: data[row][damageType + damageTypes.length + 1]};
-            }
-        }
-
-        return new ResistanceStats(damageTypeToResistance);
-    }
-
     get(damageType: DamageType) : ResistanceStat {
         return this.damageTypeToResistance[damageType];
     }

--- a/src/tests/attack_calculator.test.ts
+++ b/src/tests/attack_calculator.test.ts
@@ -13,6 +13,14 @@ let defender: Character;
 function resetValues() {
     // As of time of writing, profile does not impact damage calculations. This will change in the future
     const dummyProfile = new Profile({} as Record<Skills, number>, 0, 0, 0, '');
+    const zeroAttrStatsMap = new Map<string, number>([
+        ['CON', 0],
+        ['STR', 0],
+        ['DEX', 0],
+        ['WIS', 0],
+        ['INT', 0],
+        ['CHAR', 0],
+    ]);
 
     // These are set to "identity" values (i.e. 0 for adding, 1 for multiplying) for ease of reasoning in tests
     const attackerWeapon: Weapon = {
@@ -24,7 +32,8 @@ function resetValues() {
         damageMultiplier: 1,
         difficultyClass: 0,
     };
-    attacker = new Character(AttributeStats.buildEmpty(), ResistanceStats.buildEmpty(), attackerWeapon, dummyProfile);
+    attacker = new Character(
+        AttributeStats.buildFromMap(zeroAttrStatsMap), ResistanceStats.buildEmpty(), attackerWeapon, dummyProfile);
 
     const defenderWeapon: Weapon = {
         attribute: Attribute.Dexterity,
@@ -35,7 +44,8 @@ function resetValues() {
         damageMultiplier: 1,
         difficultyClass: 0,
     };
-    defender = new Character(AttributeStats.buildEmpty(), ResistanceStats.buildEmpty(), defenderWeapon, dummyProfile);
+    defender = new Character(
+        AttributeStats.buildFromMap(zeroAttrStatsMap), ResistanceStats.buildEmpty(), defenderWeapon, dummyProfile);
 }
 
 beforeEach(resetValues);

--- a/src/tests/attack_calculator.test.ts
+++ b/src/tests/attack_calculator.test.ts
@@ -4,7 +4,7 @@ import { Attribute, AttackType, DamageType, Skills } from 'base_game_enums';
 import { Character } from 'character';
 import { Profile } from 'profile';
 import { ResistanceStats } from 'resistance_stats';
-import { enumerateEnumValues } from 'utils';
+import { arrayToMap, enumerateEnumValues } from 'utils';
 import { Weapon } from 'weapon';
 
 let attacker: Character;
@@ -13,16 +13,16 @@ let defender: Character;
 function resetValues() {
     // As of time of writing, profile does not impact damage calculations. This will change in the future
     const dummyProfile = new Profile({} as Record<Skills, number>, 0, 0, 0, '');
-    const zeroAttrStatsMap = new Map<string, number>([
-        ['CON', 0],
-        ['STR', 0],
-        ['DEX', 0],
-        ['WIS', 0],
-        ['INT', 0],
-        ['CHAR', 0],
-    ]);
 
     // These are set to "identity" values (i.e. 0 for adding, 1 for multiplying) for ease of reasoning in tests
+    const zeroAttrStatsMap = new Map<string, number>([
+        ['CON', 0], ['STR', 0], ['DEX', 0], ['WIS', 0], ['INT', 0], ['CHAR', 0],
+    ]);
+
+    const resStatsMapKeys = enumerateEnumValues<DamageType>(DamageType)
+        .flatMap(dt => [`${DamageType[dt]}%`, `${DamageType[dt]} Flat`]);
+    const zeroResStatsMap = arrayToMap(resStatsMapKeys, k => k, () => 0);
+
     const attackerWeapon: Weapon = {
         attribute: Attribute.Dexterity,
         attackType: AttackType.Strike,
@@ -33,7 +33,11 @@ function resetValues() {
         difficultyClass: 0,
     };
     attacker = new Character(
-        AttributeStats.buildFromMap(zeroAttrStatsMap), ResistanceStats.buildEmpty(), attackerWeapon, dummyProfile);
+        AttributeStats.buildFromMap(zeroAttrStatsMap),
+        ResistanceStats.buildFromMap(zeroResStatsMap),
+        attackerWeapon,
+        dummyProfile
+    );
 
     const defenderWeapon: Weapon = {
         attribute: Attribute.Dexterity,
@@ -45,7 +49,11 @@ function resetValues() {
         difficultyClass: 0,
     };
     defender = new Character(
-        AttributeStats.buildFromMap(zeroAttrStatsMap), ResistanceStats.buildEmpty(), defenderWeapon, dummyProfile);
+        AttributeStats.buildFromMap(zeroAttrStatsMap),
+        ResistanceStats.buildFromMap(zeroResStatsMap),
+        defenderWeapon,
+        dummyProfile
+    );
 }
 
 beforeEach(resetValues);

--- a/src/tests/attack_calculator.test.ts
+++ b/src/tests/attack_calculator.test.ts
@@ -12,6 +12,8 @@ let defender: Character;
 
 function resetValues() {
     // As of time of writing, profile does not impact damage calculations. This will change in the future
+    // Note that when it does, this should likely be refactored so attack_calculator doesn't need to know as much about
+    // the individual classes, just the character (and maybe weapons/abilities)
     const dummyProfile = new Profile({} as Record<Skills, number>, 0, 0, 0, '');
 
     // These are set to "identity" values (i.e. 0 for adding, 1 for multiplying) for ease of reasoning in tests

--- a/src/tests/attribute_stats.test.ts
+++ b/src/tests/attribute_stats.test.ts
@@ -1,12 +1,31 @@
 import { AttributeStats } from 'attribute_stats';
 import { Attribute, EvasiveStatType } from 'base_game_enums';
-import { enumerateEnumValues } from 'utils';
 
-test('buildEmpty initializes stats to 0', () => {
-    const attributeStats = AttributeStats.buildEmpty();
-    for (const attribute of enumerateEnumValues<Attribute>(Attribute)) {
-        expect(attributeStats.get(attribute)).toBe(0);
-    }
+describe('buildFromMap', () => {
+    test('initializes correctly', () => {
+        const attributeStats = AttributeStats.buildFromMap(new Map<string, number>([
+            ['CON', 1],
+            ['STR', 2],
+            ['DEX', 3],
+            ['WIS', 4],
+            ['INT', 5],
+            ['CHAR', 6],
+            ['N/A', 10]
+        ]));
+
+        expect(attributeStats.get(Attribute.Constitution)).toBe(1);
+        expect(attributeStats.get(Attribute.Strength)).toBe(2);
+        expect(attributeStats.get(Attribute.Dexterity)).toBe(3);
+        expect(attributeStats.get(Attribute.Wisdom)).toBe(4);
+        expect(attributeStats.get(Attribute.Intelligence)).toBe(5);
+        expect(attributeStats.get(Attribute.Charisma)).toBe(6);
+    });
+
+    test('throws when attr not found', () => {
+        expect(() => {
+            AttributeStats.buildFromMap(new Map<string, number>([['CON', 1], ['STR', 2]]));
+        }).toThrowError();
+    });
 });
 
 test('getEvasiveStat uses correct attributes', () => {

--- a/src/tests/attribute_stats.test.ts
+++ b/src/tests/attribute_stats.test.ts
@@ -22,9 +22,7 @@ describe('buildFromMap', () => {
     });
 
     test('throws when attr not found', () => {
-        expect(() => {
-            AttributeStats.buildFromMap(new Map<string, number>([['CON', 1], ['STR', 2]]));
-        }).toThrowError();
+        expect(() => AttributeStats.buildFromMap(new Map<string, number>([['CON', 1], ['STR', 2]]))).toThrowError();
     });
 });
 

--- a/src/tests/resistance_stats.test.ts
+++ b/src/tests/resistance_stats.test.ts
@@ -1,10 +1,47 @@
 import { DamageType } from 'base_game_enums';
 import { ResistanceStats } from 'resistance_stats';
-import { enumerateEnumValues } from 'utils';
 
-test('buildEmpty initializes stats to 0', () => {
-    const resistanceStats = ResistanceStats.buildEmpty();
-    for (const damageType of enumerateEnumValues<DamageType>(DamageType)) {
-        expect(resistanceStats.get(damageType)).toStrictEqual({percent: 0, flat: 0});
-    }
+describe('buildFromMap', () => {
+    let resStatsMap : Map<string, number>;
+
+    beforeEach(() => {
+        resStatsMap = new Map<string, number>([
+            ['Slashing%', 1], ['Slashing Flat', 2],
+            ['Bludgeoning%', 3], ['Bludgeoning Flat', 4],
+            ['Piercing%', 5], ['Piercing Flat', 6],
+            ['Fire%', 7], ['Fire Flat', 8],
+            ['Water%', 9], ['Water Flat', 10],
+            ['Air%', 11], ['Air Flat', 12],
+            ['Earth%', 13], ['Earth Flat', 14],
+            ['Poison%', 15], ['Poison Flat', 16],
+            ['Radiant%', 17], ['Radiant Flat', 18],
+            ['Necrotic%', 19], ['Necrotic Flat', 20],
+            ['Psychic%', 21], ['Psychic Flat', 22],
+        ]);
+    });
+
+    test('initializes correctly', () => {
+        const resStats = ResistanceStats.buildFromMap(resStatsMap);
+        expect(resStats.get(DamageType.Slashing)).toStrictEqual({percent: 0.01, flat: 2});
+        expect(resStats.get(DamageType.Bludgeoning)).toStrictEqual({percent: 0.03, flat: 4});
+        expect(resStats.get(DamageType.Piercing)).toStrictEqual({percent: 0.05, flat: 6});
+        expect(resStats.get(DamageType.Fire)).toStrictEqual({percent: 0.07, flat: 8});
+        expect(resStats.get(DamageType.Water)).toStrictEqual({percent: 0.09, flat: 10});
+        expect(resStats.get(DamageType.Air)).toStrictEqual({percent: 0.11, flat: 12});
+        expect(resStats.get(DamageType.Earth)).toStrictEqual({percent: 0.13, flat: 14});
+        expect(resStats.get(DamageType.Poison)).toStrictEqual({percent: 0.15, flat: 16});
+        expect(resStats.get(DamageType.Radiant)).toStrictEqual({percent: 0.17, flat: 18});
+        expect(resStats.get(DamageType.Necrotic)).toStrictEqual({percent: 0.19, flat: 20});
+        expect(resStats.get(DamageType.Psychic)).toStrictEqual({percent: 0.21, flat: 22});
+    });
+
+    test('throws when flat damage type not found', () => {
+        resStatsMap.delete('Psychic Flat');
+        expect(() => ResistanceStats.buildFromMap(resStatsMap)).toThrowError();
+    });
+
+    test('throws when percent damage type not found', () => {
+        resStatsMap.delete('Psychic%');
+        expect(() => ResistanceStats.buildFromMap(resStatsMap)).toThrowError();
+    });
 });

--- a/src/tests/weapon.test.ts
+++ b/src/tests/weapon.test.ts
@@ -1,0 +1,49 @@
+import { AttackType, Attribute, DamageType } from 'base_game_enums';
+import { Weapon } from 'weapon';
+
+describe('buildFromMap', () => {
+    let weapMap : Map<string, any>;
+
+    beforeEach(() => {
+        weapMap = new Map<string, any>([
+            ['Type', 'Strike'],
+            ['Hit DC', 5],
+            ['Damage Type', 'Slashing'],
+            ['Primary Attribute', 'STR'],
+            ['To Hit Multiplier', 1],
+            ['Damage Multiplier', 2],
+            ['Base Damage', 3]
+        ]);
+    });
+
+    test('initializes correctly', () => {
+        const weapon = Weapon.buildFromMap(weapMap);
+        expect(weapon.attackType).toBe(AttackType.Strike);
+        expect(weapon.difficultyClass).toBe(5);
+        expect(weapon.damageType).toBe(DamageType.Slashing);
+        expect(weapon.attribute).toBe(Attribute.Strength);
+        expect(weapon.toHitMultiplier).toBe(1);
+        expect(weapon.damageMultiplier).toBe(2);
+        expect(weapon.baseDamage).toBe(3);
+    });
+
+    test('throws when attack type lookup fails', () => {
+        weapMap.set('Type', 'N/A');
+        expect(() => Weapon.buildFromMap(weapMap)).toThrowError();
+    });
+
+    test('throws when damage type lookup fails', () => {
+        weapMap.set('Damage Type', 'N/A');
+        expect(() => Weapon.buildFromMap(weapMap)).toThrowError();
+    });
+
+    test('throws when attribute lookup fails', () => {
+        weapMap.set('Primary Attribute', 'N/A');
+        expect(() => Weapon.buildFromMap(weapMap)).toThrowError();
+    });
+
+    test('throws when key not found', () => {
+        weapMap.delete('Hit DC');
+        expect(() => Weapon.buildFromMap(weapMap)).toThrowError();
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,21 @@ export function enumerateEnumValues<EnumClass>(enumClass: any) : EnumClass[] {
         .filter(v => typeof(v) === 'string')
         .map((v) => enumClass[v as string]);
 }
+
+export function getNonNull<T>(value: T | null | undefined) : T {
+    if (value === null || value === undefined) {
+        throw `Expected nonNull value, but receieved ${value}`;
+    }
+    return value!;
+}
+
+export function arrayToMap<T, Value>(array: T[], getStringKey: (t: T) => string, getValue: (t: T) => Value)
+    : Map<string, Value> {
+    const map: Map<string, Value> = new Map();
+    return array
+        .map(t => {return {key: getStringKey(t), value: getValue(t)};})
+        .reduce((m, kv) => {
+            m.set(kv.key, kv.value);
+            return m;
+        }, map);
+}

--- a/src/weapon.ts
+++ b/src/weapon.ts
@@ -1,6 +1,7 @@
-import { Attribute, AttackType, DamageType } from 'base_game_enums';
+import { Attribute, AttackType, DamageType, getAttrFromAbbrev } from 'base_game_enums';
+import { getNonNull } from 'utils';
 
-export interface Weapon {
+export class Weapon {
     attribute: Attribute;
     attackType: AttackType;
     damageType: DamageType;
@@ -8,4 +9,33 @@ export interface Weapon {
     toHitMultiplier: number;
     damageMultiplier: number;
     difficultyClass: number;
+
+    constructor(
+        attr: Attribute,
+        atkType: AttackType,
+        dmgType: DamageType,
+        baseDmg: number,
+        toHitMult: number,
+        dmgMult: number,
+        diffCls: number) {
+        this.attribute = attr;
+        this.attackType = atkType;
+        this.damageType = dmgType;
+        this.baseDamage = baseDmg;
+        this.toHitMultiplier = toHitMult;
+        this.damageMultiplier = dmgMult;
+        this.difficultyClass = diffCls;
+    }
+
+    static buildFromMap(map: Map<string, any>) : Weapon {
+        const attribute = getAttrFromAbbrev(getNonNull(map.get('Primary Attribute')));
+        const atkType = getNonNull(AttackType[map.get('Type') as keyof typeof AttackType]);
+        const dmgType = getNonNull(DamageType[map.get('Damage Type') as keyof typeof DamageType]);
+        const baseDmg = getNonNull(map.get('Base Damage'));
+        const toHitMult = getNonNull(map.get('To Hit Multiplier'));
+        const dmgMult = getNonNull(map.get('Damage Multiplier'));
+        const diffCls = getNonNull(map.get('Hit DC'));
+
+        return new Weapon(attribute, atkType, dmgType, baseDmg, toHitMult, dmgMult, diffCls);
+    }
 }


### PR DESCRIPTION
Number of changes/ cleanups so we can play nice with the new Google Sheet, as well as the actual biz logic implementation.

- Move all the google sheets loading code to `gsheets/loader.ts`, and make that return a map
- For all the "game logic" classes, create a `buildFromMap` function that takes in the map the loader returns. The separation between "loading logic" and "game logic" should hopefully make the code cleaner and easier to work on separately
- Clicking the `calculate` button in our sheets now loads the chars and does "proper" calcs!