### PR TITLE
Support passing attacks into attack calc functions

### DIFF
--- a/src/attack_calculator.ts
+++ b/src/attack_calculator.ts
@@ -1,9 +1,20 @@
+import { Attribute, AttackType, DamageType, } from 'base_game_enums';
 import { Character } from 'character';
 
 interface ToHitResults {
     doesAttackHit: boolean;
     attackerToHit: number;
     defenderEvade: number;
+}
+
+export interface Attack {
+    attribute: Attribute;
+    attackType: AttackType;
+    damageType: DamageType;
+    baseDamage: number;
+    toHitMultiplier: number;
+    damageMultiplier: number;
+    difficultyClass: number;
 }
 
 /*
@@ -13,13 +24,13 @@ Not yet implemented for toHit:
 - Eventually probs some passives that modify to hit in certain situations, both for attacker/defender(s)
 - Dual wield - toHit
  */
-export function calculateToHit(roll: number, attacker: Character, defender: Character) : ToHitResults {
+export function calculateToHit(roll: number, attacker: Character, defender: Character, attack: Attack) : ToHitResults {
     const attackerToHitScalingFactor = Math.ceil(
-        attacker.getAttributeStat(attacker.weapon.attribute) *
-        attacker.weapon.toHitMultiplier
+        attacker.getAttributeStat(attack.attribute) *
+        attack.toHitMultiplier
     );
-    const attackerToHit = attackerToHitScalingFactor - attacker.weapon.difficultyClass + roll;
-    const defenderEvade = defender.getEvasiveStatForAttackType(attacker.weapon.attackType);
+    const attackerToHit = attackerToHitScalingFactor - attack.difficultyClass + roll;
+    const defenderEvade = defender.getEvasiveStatForAttackType(attack.attackType);
 
     return {
         doesAttackHit: attackerToHit >= defenderEvade,
@@ -34,13 +45,13 @@ Not yet implemented for damage:
 - Crits do extra 50% damage
 - Two handing weapon multiplier
 */
-export function calculateDamage(attacker: Character, defender: Character) : number {
+export function calculateDamage(attacker: Character, defender: Character, attack: Attack) : number {
     const attackerDamageScalingFactor = Math.ceil(
-        attacker.getAttributeStat(attacker.weapon.attribute) *
-        attacker.weapon.damageMultiplier
+        attacker.getAttributeStat(attack.attribute) *
+        attack.damageMultiplier
     );
-    const attackerDamage = attackerDamageScalingFactor + attacker.weapon.baseDamage;
-    const defenderRes = defender.getResistanceStat(attacker.weapon.damageType);
+    const attackerDamage = attackerDamageScalingFactor + attack.baseDamage;
+    const defenderRes = defender.getResistanceStat(attack.damageType);
     const calcDmg = Math.ceil(attackerDamage * (1 - defenderRes.percent)) - defenderRes.flat;
     return Math.max(calcDmg, 1);
 }

--- a/src/character.ts
+++ b/src/character.ts
@@ -2,19 +2,15 @@ import { AttributeStats } from 'attribute_stats';
 import { Attribute, Skills, AttackType, DamageType } from 'base_game_enums';
 import { Profile } from 'profile';
 import { ResistanceStat, ResistanceStats } from 'resistance_stats';
-import { Weapon } from 'weapon';
-
 
 export class Character {
     attributeStats: AttributeStats;
     resistanceStats: ResistanceStats;
-    weapon: Weapon;
     profile: Profile;
 
-    constructor(attrStats: AttributeStats, resStats: ResistanceStats, weap: Weapon, prof: Profile) {
+    constructor(attrStats: AttributeStats, resStats: ResistanceStats, prof: Profile) {
         this.attributeStats = attrStats;
         this.resistanceStats = resStats;
-        this.weapon = weap;
         this.profile = prof;  // as of time of writing, unused in real code
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { calculateToHit, calculateDamage } from 'attack_calculator';
+import { calculateToHit, calculateDamage, Attack } from 'attack_calculator';
 import { AttributeStats } from 'attribute_stats';
 import { Skills } from 'base_game_enums';
 import { Character } from 'character';
@@ -6,7 +6,6 @@ import { loadItem } from 'gsheets/loader';
 import { Profile } from 'profile';
 import { ResistanceStats } from 'resistance_stats';
 import { getNonNull, arrayToMap } from 'utils';
-import { Weapon } from 'weapon';
 
 function loadCharacter(characterName: string) : Character {
     // As of time of writing, profile does not impact damage calculations. This will change in the future
@@ -14,12 +13,10 @@ function loadCharacter(characterName: string) : Character {
 
     const unitMap = loadItem('Units', characterName, true);
     const armorMap = loadItem('Armors', unitMap.get('Armor'), false);
-    const weaponMap = loadItem('Weapons', unitMap.get('Weapons'), true);
 
     return new Character(
         AttributeStats.buildFromMap(unitMap),
         ResistanceStats.buildFromMap(armorMap),
-        Weapon.buildFromMap(weaponMap),
         dummyProfile);
 }
 
@@ -36,8 +33,9 @@ global.calculateAttack = () => {
     const attacker = loadCharacter(attackerName);
     const defender = loadCharacter(defenderName);
 
-    const toHitResult = calculateToHit(roll, attacker, defender);
-    const damage = calculateDamage(attacker, defender);
+    // stopping build complaints, this code is changing later anyways
+    const toHitResult = calculateToHit(roll, attacker, defender, {} as Attack);
+    const damage = calculateDamage(attacker, defender, {} as Attack);
 
     getNonNull(nameToRange.get('attackerToHit')).setValue(toHitResult.attackerToHit);
     getNonNull(nameToRange.get('defenderEvade')).setValue(toHitResult.defenderEvade);

--- a/src/tests/character.test.ts
+++ b/src/tests/character.test.ts
@@ -3,16 +3,14 @@ import { AttackType, Attribute, DamageType, Skills } from 'base_game_enums';
 import { Character } from 'character';
 import { Profile } from 'profile';
 import { ResistanceStat, ResistanceStats } from 'resistance_stats';
-import { Weapon } from 'weapon';
 
 import { when } from 'jest-when';
 
 const mockAttrStats = { get: jest.fn() } as any as AttributeStats;
 const mockResStats = { get: jest.fn() } as any as ResistanceStats;
-const mockWeapon = {} as any as Weapon;  // unused
 const mockProfile = {} as any as Profile;  // unused for now
 
-const character = new Character(mockAttrStats, mockResStats, mockWeapon, mockProfile);
+const character = new Character(mockAttrStats, mockResStats, mockProfile);
 
 test('getAttributeStat', () => {
     when(mockAttrStats.get).expectCalledWith(Attribute.Dexterity).mockReturnValueOnce(50);


### PR DESCRIPTION
Creates a new `Attack` interface for attack calcs to use. For now this is a copy paste of the `Weapon` member variables, but I envision `Weapon` and `Ability` going their own separate ways and us just needing to know how to translate any kind of attack to this `Attack` interface.